### PR TITLE
Fix up site.title and site.author links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: minima
+site: Under the Lamplight
+author: Bouteillebleu

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Under the Lamplight
+title: All posts
 ---
 
 {% for post in site.posts %}


### PR DESCRIPTION
After reading the Minima layout templates, searching the Jekyll docs, and reading SO posts, I now understand better what the various configuration options do.

Changes made here:
* Move the blog title into `site.title`, set in the config file.
* Also set the site author in the config file.
* Give the index page a very plain name so its link is descriptive.